### PR TITLE
allow custom class for individual posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ Create a Google Spreadsheet with the following columns:
 * caption
 * body 
 * read more url
+* class
 
 **Please note that the the _display date_ column must be in the format _Month day, Year_ (April 25, 2012) for proper javascript parsing.**
 **Also, all columns must be _plain text_ format, including the two date columns.**
+
+The _class_ value will be added to the class attribute of the main div for that post, to support custom css.
 
 Now follow the instructions over at Tabletop.js to publish the Spreadsheet.
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,13 @@
   <link rel="stylesheet" href="css/style.css">
 
   <script src="js/libs/modernizr-2.5.3.min.js"></script>
+  <style type="text/css">
+	  /* class "negative" makes post appear white on black */
+	.negative div.inner, .negative div, .negative h3 {
+		background: #000 !important;
+		color: #fff !important
+	} 
+  </style>
 </head>
 <body>
   <div id="page">
@@ -68,7 +75,7 @@
   </script>
 
   <script id="post-template" type="text/x-handlebars-template">
-    <div class="item post">
+	  <div class="item post {{class}}">
       <div class="inner">
         <div class="timestamp">{{timestamp}}</div>
         <div class="title"><h3>{{title}}</h3></div>


### PR DESCRIPTION
Another very small change: allow custom class on post divs by adding a column "class" to the Google spreadsheet. This permits customizing the css for different types of posts.
